### PR TITLE
Fix share menu margin

### DIFF
--- a/assets/css/post-generator.css
+++ b/assets/css/post-generator.css
@@ -181,7 +181,7 @@ button.success:hover {
 /* Share Button and Dropdown Menu */
 .share-button-container {
     position: relative;
-    display: inline-block;
+    display: inline-block;   
 }
 
 .share-button {
@@ -330,7 +330,7 @@ img {
   /* Share button styles */
   .share-menu {
     display: none;
-    margin-top: 10px;
+    margin-top: 1px;
   }
   
   .share-button-container:hover .share-menu {


### PR DESCRIPTION
The menu would open but as soon as the button lost focus it would disappear so the user had no chance to click any of the items